### PR TITLE
added require legacy_formatters to work with rspec3

### DIFF
--- a/lib/tasks/docs.rake
+++ b/lib/tasks/docs.rake
@@ -4,6 +4,6 @@ if Rails.env.test? || Rails.env.development?
   desc 'Generate API request documentation from API specs'
   RSpec::Core::RakeTask.new('docs:generate') do |t|
     t.pattern = 'spec/acceptance/**/*_spec.rb'
-    t.rspec_opts = ["--format RspecApiDocumentation::ApiFormatter"]
+    t.rspec_opts = ["--require rspec/legacy_formatters --format RspecApiDocumentation::ApiFormatter"]
   end
 end


### PR DESCRIPTION
rspec3移行にともなってrspec_legacy_formattersが必要になったが、rspec_legacy_formattersを常時requireすると、rspecエラー時のログが異常なスタックトレースになり、原因が解析しにくくなるため、api生成時のみrequireするよう修正。
